### PR TITLE
adding missing script_location parameter to spark command.

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/api/SparkCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/SparkCommandBuilder.java
@@ -76,4 +76,10 @@ public interface SparkCommandBuilder extends InvokableBuilder<CommandResponse>
      * from the commands list in the Commands History.
      */
     public SparkCommandBuilder tags(String[] queryTags);
+    
+    /**
+     * Specify an S3 path where the Spark query (Scala, Python, SQL, R, and Command Line) script is stored.
+     */
+    public SparkCommandBuilder scriptLocation(String scriptLocation);
+
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/SparkCommandBuilderImpl.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/SparkCommandBuilderImpl.java
@@ -86,6 +86,12 @@ public class SparkCommandBuilderImpl extends CommandBuilderImplBase implements S
     }
 
     @Override
+    public SparkCommandBuilder scriptLocation(String scriptLocation) {
+        node.put("script_location", scriptLocation);
+        return this;
+    }
+
+    @Override
     protected ObjectNode getEntity()
     {
         return node;


### PR DESCRIPTION
This code provides details about how to set script_location via SparkCommandBuilder.

@tan31989 please review the changes.